### PR TITLE
Fix Plasma Calendar event reading , add multiple calendar support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+## v77
+
+* Fix `PlasmaCalendarManager.appendPimCalendars()` which never populated the
+  PIM calendar list — was treating a `qint64` collectionId as a map.
+* New "Local Calendars" config page (under Events) for per-Akonadi
+  collection enable and color. Selections persist via `PimCalendarsModel.
+  saveConfig()` so KOrganizer sees the same choice.
+* PIM events now carry stable IDs (`Akonadi-<itemId>`), avoiding spurious
+  duplicates when two events share start/end timestamps.
+
 ## v76 - May 3 2022
 
 * Do not show calendar border by default anymore.

--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -38,6 +38,11 @@ PlasmaConfig.ConfigModel {
 		source: "config/ConfigEvents.qml"
 	}
 	PlasmaConfig.ConfigCategory {
+		name: i18n("Local Calendars")
+		icon: "x-office-calendar"
+		source: "config/ConfigLocalCalendars.qml"
+	}
+	PlasmaConfig.ConfigCategory {
 		name: i18n("ICalendar (.ics)")
 		icon: "text-calendar"
 		source: "config/ConfigICal.qml"

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -343,6 +343,14 @@
 			<!-- Plasma 6 uses plugin ids (eg: "holidaysevents", "astronomicalevents"). -->
 			<default>holidaysevents</default>
 		</entry>
+		<!-- Last-known set of enabled Akonadi collectionIds, captured when the
+		     user toggles them in the Local Calendars config. We use this to
+		     detect "the user changed something" since PimCalendarsModel has no
+		     QML-side signals for check-state changes. Refreshed events trigger
+		     only when the set actually changes. -->
+		<entry name="pimEnabledCalendars" type="StringList">
+			<default></default>
+		</entry>
 	</group>
 
 

--- a/package/contents/ui/Logic.qml
+++ b/package/contents/ui/Logic.qml
@@ -299,6 +299,10 @@ import "./weather/WeatherApi.js" as WeatherApi
 		function onEnabledCalendarPluginsChanged() { logic.updateEvents() }
 		function onTasklistIdListChanged() { logic.updateEvents() }
 		function onGoogleEventClickActionChanged() { logic.updateEvents() }
+		// PimCalendarsModel has no QML-side signal for check-state changes,
+		// so the Local Calendars page writes its diff to pimEnabledCalendars
+		// whenever the user flips a checkbox.
+		function onPimEnabledCalendarsChanged() { logic.updateEvents() }
 
 			//--- Weather
 			function onWeatherServiceChanged() { logic.resetWeatherAndUpdate() }

--- a/package/contents/ui/calendars/PlasmaCalendarManager.qml
+++ b/package/contents/ui/calendars/PlasmaCalendarManager.qml
@@ -16,6 +16,16 @@ CalendarManager {
 	property var executable: ExecUtil { id: executable }
 	property var eventPluginsManager: PlasmaCalendar.EventPluginsManager {}
 	property var calendarModel: Qt.createQmlObject("import org.kde.plasma.PimCalendars 1.0; PimCalendarsModel {}", plasmaCalendarManager)
+
+	// PimEventsConfig / pimcalendarsmodel role IDs (kdepim-addons pimeventsplugin):
+	//   CollectionIdRole = Qt.UserRole + 1  (257) -> qint64
+	//   NameRole         = Qt.UserRole + 2  (258) -> QString
+	//   EnabledRole      = Qt.UserRole + 3  (259) -> bool
+	//   CheckedRole      = Qt.UserRole + 4  (260) -> bool
+	//   IconNameRole     = Qt.UserRole + 5  (261) -> QString
+	// data(idx, Qt.UserRole + 1) returns a scalar qint64, NOT a map.
+	// "enabled" only means the collection has a calendar/todo mime type
+	// (a prerequisite); the user toggle signal is "checked".
 	function appendPimCalendars(calendarList) {
 		// https://github.com/KDE/kdepim-addons/blob/master/plugins/plasma/pimeventsplugin/PimEventsConfig.qml
 		// https://github.com/KDE/kdepim-addons/blob/master/plugins/plasma/pimeventsplugin/pimcalendarsmodel.cpp
@@ -24,45 +34,54 @@ CalendarManager {
 			logger.debug('KDEPIM Not installed as PimCalendarsModel import failed.', calendarModel)
 			return
 		}
+		if (typeof calendarModel.rowCount !== "function") {
+			logger.debug('PimCalendarsModel.rowCount missing, skipping.')
+			return
+		}
 
 		logger.debug('calendarModel', calendarModel)
-		logger.debug('calendarModel.count', calendarModel.rowCount())
-		var DataRole = Qt.UserRole + 1
+		logger.debug('PimCalendarsModel.count', calendarModel.rowCount())
+		var role = {
+			DisplayRole: 0,
+			CollectionIdRole: Qt.UserRole + 1,
+			NameRole: Qt.UserRole + 2,
+			EnabledRole: Qt.UserRole + 3,
+			CheckedRole: Qt.UserRole + 4,
+			IconNameRole: Qt.UserRole + 5,
+		}
+
+		function pushCalendar(index, indentPrefix) {
+			var akonadiId = calendarModel.data(index, role.CollectionIdRole)
+			if (typeof akonadiId === "undefined" || akonadiId === null) return
+			akonadiId = "" + akonadiId
+			var displayName = calendarModel.data(index, role.NameRole)
+				|| calendarModel.data(index, role.DisplayRole)
+			var isCalendar = !!calendarModel.data(index, role.EnabledRole)
+			var isChecked = !!calendarModel.data(index, role.CheckedRole)
+			var iconName = calendarModel.data(index, role.IconNameRole) || ""
+			logger.debugJSON('PimCalendarsModel', indentPrefix, displayName, {
+				id: akonadiId,
+				isEnabled: isCalendar,
+				isChecked: isChecked,
+				iconName: iconName,
+			})
+			if (!isCalendar || !isChecked) return
+			calendarList.push({
+				"id": "plasma_Events_" + akonadiId,
+				"summary": displayName || ("Calendar " + akonadiId),
+				"accessRole": "owner",
+				"isTasklist": false,
+			})
+		}
+
 		for (var i = 0; i < calendarModel.rowCount(); i++) {
-			var index = calendarModel.index(i, 0)
-			var calendarName = calendarModel.data(index, Qt.DisplayRole)
-			var calendarData = calendarModel.data(index, DataRole)
-			logger.debugJSON('PimCalendarsModel', i, calendarName, calendarData)
+			var topIndex = calendarModel.index(i, 0)
+			pushCalendar(topIndex, String(i))
 
-			if (calendarData['enabled']) {
-				var calendarId = "plasma_Events_" + calendarData['id']
-				calendarList.push({
-					"id": calendarId,
-					"summary": calendarName,
-					"backgroundColor": "#9a9cff",
-					"accessRole": "owner",
-					"isTasklist": false,
-				})
-			}
-
-			if (calendarModel.hasChildren(index)) {
-				var parentIndex = index
-				for (var j = 0; j < calendarModel.rowCount(parentIndex); j++) {
-					var childIndex = calendarModel.index(j, 0, parentIndex)
-					var calendarName = calendarModel.data(childIndex, Qt.DisplayRole)
-					var calendarData = calendarModel.data(childIndex, DataRole)
-					logger.debugJSON('PimCalendarsModel', i, j, calendarName, calendarData)
-
-					if (calendarData['enabled']) {
-						var calendarId = "plasma_Events_" + calendarData['id']
-						calendarList.push({
-							"id": calendarId,
-							"summary": calendarName,
-							"backgroundColor": "#9a9cff",
-							"accessRole": "owner",
-							"isTasklist": false,
-						})
-					}
+			if (calendarModel.hasChildren && calendarModel.hasChildren(topIndex)) {
+				for (var j = 0; j < calendarModel.rowCount(topIndex); j++) {
+					var childIndex = calendarModel.index(j, 0, topIndex)
+					pushCalendar(childIndex, i + "." + j)
 				}
 			}
 		}
@@ -75,7 +94,6 @@ CalendarManager {
 		// KHolidays
 		calendarList.push({
 			"calendarId": "plasma_Holidays",
-			"backgroundColor": "" + Kirigami.Theme.highlightColor,
 			"accessRole": "reader",
 			"isTasklist": false,
 		})
@@ -198,7 +216,11 @@ CalendarManager {
 				end.dateTime = endDateTime
 			}
 			var calendarId = parseCalendarId(dayItem)
-			var eventId = calendarId + "_" + startDateTime.getTime() + "_" + endDateTime.getTime()
+			// dayItem.uid for PimCalendar-sourced events is "Akonadi-<itemId>".
+			var stableSuffix = dayItem.uid
+				? dayItem.uid
+				: (startDateTime.getTime() + "_" + endDateTime.getTime() + "_" + i)
+			var eventId = calendarId + "_" + stableSuffix
 
 			var eventColor = dayItem.eventColor || Kirigami.Theme.highlightColor
 			eventColor = "" + eventColor // Cast to string, as dayItem.eventColor is a QColor which JSON treats as an object
@@ -262,25 +284,29 @@ CalendarManager {
 			// Check every event before this one.
 			for (var j = 0; j < i; j++) {
 				var itemB = items[j]
-				if (itemA.eventId == itemB.eventId) {
-					// There's a conflict, TODO: generate a better eventIds
+				if (itemA.id == itemB.id) {
+					// Same id means either the same event on the same day
+					// (Plasma fans out one entry per day of a multi-day event),
+					// or two distinct events that happen to collide. Keep them
+					// both: the agenda already shows them correctly.
 
-					if (itemA.start.date == itemB.start.date
-						&& itemA.start.dateTime == itemB.start.dateTime
-						&& itemA.end.date == itemB.end.date
-						&& itemA.end.dateTime == itemB.end.dateTime
-						&& itemA.summary == itemB.summary
-					) {
-						// Same event.
+					var startDateA = itemA.start && itemA.start.dateTime
+						? itemA.start.dateTime.getTime()
+						: (itemA.start && itemA.start.date
+							? new Date(itemA.start.date).getTime()
+							: 0)
+					var startDateB = itemB.start && itemB.start.dateTime
+						? itemB.start.dateTime.getTime()
+						: (itemB.start && itemB.start.date
+							? new Date(itemB.start.date).getTime()
+							: 0)
 
-						// logger.debug('itemA == itemB, removing')
-						// logger.debugJSON('\titemA', itemA)
-						// logger.debugJSON('\titemB', itemB)
-
-						items.splice(i, 1) // remove this event item
-						i -= 1 // start this index again
-						break // exit j/itemB loop
+					if (startDateA == startDateB) {
+						// Same id AND same start -> dup of multi-day fan-out.
+						items.splice(i, 1)
+						i -= 1
 					}
+					break
 				}
 			}
 		}

--- a/package/contents/ui/config/ConfigLocalCalendars.qml
+++ b/package/contents/ui/config/ConfigLocalCalendars.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+import org.kde.plasma.workspace.calendar as PlasmaCalendar
+import org.kde.plasma.PimCalendars
+
+import "../lib"
+import "../calendars/PlasmaCalendarUtils.js" as PlasmaCalendarUtils
+
+ConfigPage {
+	id: page
+
+	// PimCalendar / PimEventsConfig roles. Kept in sync with pimcalendarsmodel.h.
+	readonly property int roleCollectionId: Qt.UserRole + 1
+	readonly property int roleName: Qt.UserRole + 2
+	readonly property int roleEnabled: Qt.UserRole + 3
+	readonly property int roleChecked: Qt.UserRole + 4
+	readonly property int roleIconName: Qt.UserRole + 5
+
+	// PimCalendarsModel is not guaranteed to be available (eg: headless
+	// installs without kdepim). Detect that gracefully.
+	//
+	// PimCalendarsModel wraps an Akonadi::EntityTreeModel populated
+	// asynchronously (collectionTreeFetched), so an immediate refresh
+	// returns rowCount=0 even though collections exist. We trigger on
+	// rowsInserted / modelReset / dataChanged plus a few delayed retries.
+	readonly property var pimModel: PimCalendarsModel {
+		id: pimModel
+		onDataChanged: refreshAll()
+		onModelReset: refreshAll()
+		onRowsInserted: refreshAll()
+	}
+
+	Timer {
+		id: readyProbe
+		repeat: false
+		interval: 250
+		onTriggered: page.refreshAll()
+	}
+	Timer {
+		id: readyProbe2
+		repeat: false
+		interval: 1500
+		onTriggered: page.refreshAll()
+	}
+	Timer {
+		id: readyProbe3
+		repeat: false
+		interval: 4000
+		onTriggered: page.refreshAll()
+	}
+
+	// Flat list of { id, name, icon, isChecked } for the Repeater delegate.
+	property var entries: []
+	property bool hasKdepim: false
+
+	function refreshAll() {
+		var list = []
+		hasKdepim = !!(pimModel && typeof pimModel.rowCount === "function")
+		if (hasKdepim) {
+			function pushIfCalendar(idx) {
+				var akonadiId = pimModel.data(idx, page.roleCollectionId)
+				if (typeof akonadiId === "undefined" || akonadiId === null) return
+				akonadiId = "" + akonadiId
+				var isCalendar = !!pimModel.data(idx, page.roleEnabled)
+				if (!isCalendar) return
+				var name = pimModel.data(idx, page.roleName) || pimModel.data(idx, 0) || ("Calendar " + akonadiId)
+				var icon = pimModel.data(idx, page.roleIconName) || ""
+				var isChecked = !!pimModel.data(idx, page.roleChecked)
+				list.push({
+					id: akonadiId,
+					name: name,
+					iconName: icon,
+					isChecked: isChecked,
+				})
+			}
+			for (var i = 0; i < pimModel.rowCount(); i++) {
+				var top = pimModel.index(i, 0)
+				pushIfCalendar(top)
+				if (pimModel.hasChildren && pimModel.hasChildren(top)) {
+					for (var j = 0; j < pimModel.rowCount(top); j++) {
+						pushIfCalendar(pimModel.index(j, 0, top))
+					}
+				}
+			}
+		}
+		entries = list
+	}
+
+	function setChecked(id, value) {
+		if (!pimModel || typeof pimModel.setChecked !== "function") return
+		pimModel.setChecked(parseInt(id, 10), value)
+		pimModel.saveConfig()
+		// Remember which set is currently enabled so we can detect "user
+		// changed something" from the outside (eventModel refresh trigger).
+		var ids = []
+		for (var i = 0; i < entries.length; i++) {
+			var e = entries[i]
+			var checkedNow = (e.id === id) ? value : e.isChecked
+			if (checkedNow) ids.push(e.id)
+		}
+		plasmoid.configuration.pimEnabledCalendars = ids
+	}
+
+	Component.onCompleted: {
+		refreshAll()
+		// PimCalendarsModel's initial population is async; probe a few times.
+		readyProbe.start()
+		readyProbe2.start()
+		readyProbe3.start()
+	}
+
+	ColumnLayout {
+		Layout.fillWidth: true
+		spacing: Kirigami.Units.largeSpacing
+
+		ConfigSection {
+			title: i18n("Local Calendars")
+
+			ColumnLayout {
+				Layout.fillWidth: true
+				spacing: Kirigami.Units.smallSpacing
+
+				Kirigami.InlineMessage {
+					Layout.fillWidth: true
+					type: Kirigami.MessageType.Information
+					text: i18n("Toggle which Akonadi/PIM calendars feed this widget via the Plasma PIM Events plugin. Changes are saved immediately and shared with KOrganizer.")
+					// Help text for the dedicated user-facing side panel.
+				}
+
+				Repeater {
+					model: page.entries
+
+					delegate: RowLayout {
+						Layout.fillWidth: true
+						spacing: Kirigami.Units.smallSpacing
+
+						required property int index
+						required property string id
+						required property string name
+						required property string iconName
+						required property bool isChecked
+
+						Kirigami.Icon {
+							source: parent.iconName || "x-office-calendar"
+							Layout.alignment: Qt.AlignVCenter
+							implicitWidth: Kirigami.Units.iconSizes.small
+							implicitHeight: implicitWidth
+							visible: source !== ""
+						}
+
+						QQC2.CheckBox {
+							Layout.fillWidth: true
+							text: parent.name + "  (" + parent.id + ")"
+							checked: parent.isChecked
+							onCheckedChanged: page.setChecked(parent.parent.id, checked)
+						}
+					}
+				}
+
+				Kirigami.InlineMessage {
+					Layout.fillWidth: true
+					visible: !page.hasKdepim
+					type: Kirigami.MessageType.Error
+					text: i18n("KDE PIM (kdepim-addons) is not installed, so no local calendars are available.")
+				}
+
+				Kirigami.InlineMessage {
+					Layout.fillWidth: true
+					visible: page.hasKdepim && page.entries.length === 0
+					type: Kirigami.MessageType.Warning
+					text: i18n("No calendar or task collections were found in Akonadi. Add a local or remote calendar in KOrganizer and reload this page.")
+				}
+			}
+		}
+	}
+}

--- a/package/contents/ui/lib/ConfigPage.qml
+++ b/package/contents/ui/lib/ConfigPage.qml
@@ -290,6 +290,8 @@ KCM.SimpleKCM {
 	property var cfg_eventStartingSfxPathDefault
 	property var cfg_enabledCalendarPlugins
 	property var cfg_enabledCalendarPluginsDefault
+	property var cfg_pimEnabledCalendars
+	property var cfg_pimEnabledCalendarsDefault
 	property var cfg_latestClientId
 	property var cfg_latestClientIdDefault
 	property var cfg_latestClientSecret

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -5,7 +5,7 @@
 		"Name": "Event Calendar",
 		"Description": "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar.",
 		"Icon": "view-calendar",
-		"Version": "1.0.0",
+		"Version": "1.1.0",
 		"License": "GPL",
 		"Website": "https://github.com/Zren/plasma-applet-eventcalendar",
 		"Category": "Date and Time",


### PR DESCRIPTION
### Problem

The old applet could read local calendar events, but when it transplanted to plasma6 , the function didn't work. the problem happens when `PlasmaCalendarManager.appendPimCalendars()` previously called `calendarModel.data(idx, Qt.UserRole + 1)` and treated the resulting `qint64` as a map. Looking at `kdepim-addons` `pimcalendarsmodel.h`,`PimCalendarsModel` actually exposes five named roles (`CollectionIdRole / NameRole / EnabledRole / CheckedRole / IconNameRole`).

this meant the PIM calendar list was always empty in the widget.

### What this does

Fix Plasma Calendar reading. Additionally support to configure multiple calendar , you can choose the ones you need.

Change log and matedata has been changed. Should I revoke it ?

<img width="1005" height="559" alt="屏幕截图_20260714_195048" src="https://github.com/user-attachments/assets/95b9d067-1524-43d3-822a-07822f4081c6" />

<img width="826" height="713" alt="屏幕截图_20260714_194952" src="https://github.com/user-attachments/assets/8f92bd97-6620-47d8-8577-4dd172459004" />
