### PR TITLE
Fix agenda freezes, duplicate events, and desktop rendering

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -50,6 +50,11 @@ cd plasma6-applet-eventcalendar
 sh ./install.sh
 ```
 
+The browser-based Google login requires the OAuth helper to compile. Its build
+dependencies are CMake, KDE Extra CMake Modules (ECM), and the Qt 6 NetworkAuth
+development package. If they are unavailable, the installer still installs the
+widget and the **Advanced** manual login method remains available.
+
 ### Option C: Arch Linux (AUR)
 
 Also available in the AUR as:

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ function build_oauth_helper() {
 	cmake -S "$PWD" -B "$build_dir" -DCMAKE_BUILD_TYPE=Release >/dev/null 2>&1
 	if [ $? != 0 ]; then
 		echo "[install] Warning: Failed to configure CMake (oauth helper will not be built)."
+		echo "[install] Browser login will be unavailable; use the Advanced manual login method."
 		return 0
 	fi
 
@@ -36,6 +37,7 @@ function build_oauth_helper() {
 	cmake --build "$build_dir" --target eventcalendar-google-oauth -j "$jobs" >/dev/null 2>&1
 	if [ $? != 0 ]; then
 		echo "[install] Warning: Failed to build oauth helper (eventcalendar-google-oauth)."
+		echo "[install] Browser login will be unavailable; use the Advanced manual login method."
 		return 0
 	fi
 	return 0

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -365,7 +365,8 @@
 		<entry name="accessTokenType" type="string">
 			<default></default>
 		</entry>
-		<entry name="accessTokenExpiresAt" type="uint">
+		<!-- JavaScript epoch milliseconds exceed a 32-bit unsigned integer. -->
+		<entry name="accessTokenExpiresAt" type="double">
 			<default>0</default>
 		</entry>
 		<entry name="refreshToken" type="string">

--- a/package/contents/ui/AgendaModel.qml
+++ b/package/contents/ui/AgendaModel.qml
@@ -139,55 +139,60 @@ ListModel {
 	}
 
 	function sortSubTasks(eventList) {
-		// Place subtasks below their parent task
+		// Build the hierarchy once instead of repeatedly splicing the array while
+		// iterating it. The old algorithm could move the same child back and forth
+		// forever for cyclic or unusual Google Tasks parent relationships.
+		var taskById = {}
+		var childrenByParent = {}
+		function taskKey(item, id) {
+			return (item.calendarId || '') + '\n' + (id || '')
+		}
 		for (var i = 0; i < eventList.length; i++) {
-			var eventItem = eventList[i]
-			// console.log('i', i, eventItem.summary)
-			if (eventItem.kind === 'tasks#task' && typeof eventItem.parent !== 'undefined') {
-				for (var j = 0; j < eventList.length; j++) {
-					var parentItem = eventList[j]
-					// console.log('  j', j, parentItem.summary)
-					if (parentItem.kind === 'tasks#task' && parentItem.id === eventItem.parent) {
-						var foundDestination = false
-						for (var k = j+1; k < eventList.length; k++) {
-							var childItem = eventList[k]
-							// console.log('    k', k, childItem.summary)
-							if (childItem.kind != 'tasks#task'
-								|| childItem.parent != parentItem.id
-								|| childItem.position > eventItem.position
-							) {
-								// Move eventItem from index i => k
-								// console.log('      move', eventItem.summary, 'from', i, 'to', k)
-								foundDestination = true
-								if (i < k) {
-									// Since we removed an item before k, decrement the index
-									k--
-								}
-								if (i != k) {
-									eventList.splice(i, 1) // Remove at index=i
-									eventList.splice(k, 0, eventItem) // Add at index=k
-									i-- // Since eventItem was moved, we need to check index=i again.
-								}
-								break
-							}
-						} // end loop k
-
-						if (!foundDestination) {
-							// Move eventItem from index i => end of list
-							var k = eventList.length - 1
-							// console.log('      move', eventItem.summary, 'from', i, 'to', k, '(end of list)')
-							if (i != k) {
-								eventList.splice(i, 1) // Remove at index=i
-								eventList.push(eventItem)
-								i-- // Since eventItem was moved, we need to check index=i again.
-							}
-						}
-
-						break
-					}
-				} // end loop j
+			var item = eventList[i]
+			if (item.kind !== 'tasks#task') continue
+			taskById[taskKey(item, item.id)] = item
+			if (item.parent) {
+				var parentKey = taskKey(item, item.parent)
+				if (!childrenByParent[parentKey]) childrenByParent[parentKey] = []
+				childrenByParent[parentKey].push(item)
 			}
-		} // end loop i
+		}
+
+		for (var parentId in childrenByParent) {
+			childrenByParent[parentId].sort(function(a, b) {
+				var ap = a.position || ''
+				var bp = b.position || ''
+				return ap < bp ? -1 : (ap > bp ? 1 : 0)
+			})
+		}
+
+		var ordered = []
+		var visitedTasks = {}
+		function appendTask(item) {
+			var key = taskKey(item, item.id)
+			if (visitedTasks[key]) return
+			visitedTasks[key] = true
+			ordered.push(item)
+			var children = childrenByParent[key]
+			if (!children) return
+			for (var i = 0; i < children.length; i++) appendTask(children[i])
+		}
+
+		for (var i = 0; i < eventList.length; i++) {
+			var item = eventList[i]
+			if (item.kind !== 'tasks#task') {
+				ordered.push(item)
+			} else if (!item.parent || !taskById[taskKey(item, item.parent)]) {
+				appendTask(item)
+			}
+		}
+		// Cycles have no root; append every remaining task once.
+		for (var i = 0; i < eventList.length; i++) {
+			if (eventList[i].kind === 'tasks#task') appendTask(eventList[i])
+		}
+
+		eventList.splice(0, eventList.length)
+		for (var i = 0; i < ordered.length; i++) eventList.push(ordered[i])
 	}
 
 	function parseGCalEvents(data) {

--- a/package/contents/ui/EventModel.qml
+++ b/package/contents/ui/EventModel.qml
@@ -115,11 +115,64 @@ CalendarManager {
 
 	function mergeEvents() {
 		logger.debug('eventModel.mergeEvents')
-		delete eventModel.eventsData
-		eventModel.eventsData = { items: [] }
+		var merged = []
 		for (var calendarId in eventModel.eventsByCalendar) {
-			eventModel.eventsData.items = eventModel.eventsData.items.concat(eventModel.eventsByCalendar[calendarId].items)
+			merged = merged.concat(eventModel.eventsByCalendar[calendarId].items)
 		}
+
+		function signature(item) {
+			return JSON.stringify([
+				item.summary || '',
+				Number(item.startDateTime),
+				Number(item.endDateTime),
+				item.kind === 'tasks#task' ? 'task' : 'event',
+			])
+		}
+		function isPlasmaItem(item) {
+			return (item.calendarId || '').indexOf('plasma_') === 0
+		}
+
+		var items = []
+		var itemSignatures = []
+		for (var i = 0; i < merged.length; i++) {
+			var item = merged[i]
+			var itemSignature = signature(item)
+			var itemIsPlasma = isPlasmaItem(item)
+			var isDuplicate = false
+
+			for (var j = items.length - 1; j >= 0; j--) {
+				if (itemSignatures[j] !== itemSignature) continue
+
+				var existing = items[j]
+				var sameStoredItem = !!item.id
+					&& item.id === existing.id
+					&& item.calendarId === existing.calendarId
+				if (sameStoredItem) {
+					isDuplicate = true
+					break
+				}
+
+				var existingIsPlasma = isPlasmaItem(existing)
+				if (itemIsPlasma === existingIsPlasma) continue
+
+				// Akonadi/PIM can expose the same account already fetched directly
+				// from Google. Prefer the direct item because it retains edit/link data.
+				if (itemIsPlasma) {
+					isDuplicate = true
+					break
+				}
+				items.splice(j, 1)
+				itemSignatures.splice(j, 1)
+			}
+
+			if (!isDuplicate) {
+				items.push(item)
+				itemSignatures.push(itemSignature)
+			}
+		}
+
+		delete eventModel.eventsData
+		eventModel.eventsData = { items: items }
 	}
 
 	//--- CalendarManager: Event

--- a/package/contents/ui/Logic.qml
+++ b/package/contents/ui/Logic.qml
@@ -31,7 +31,7 @@ import "./weather/WeatherApi.js" as WeatherApi
 		
 		repeat: true
 		triggeredOnStart: true
-		interval: plasmoid.configuration.eventsPollInterval * 60000
+		interval: Math.max(60000, Number(plasmoid.configuration.eventsPollInterval || 20) * 60000)
 		onTriggered: logic.update()
 	}
 
@@ -314,14 +314,14 @@ import "./weather/WeatherApi.js" as WeatherApi
 		}
 
 		//--- UI
-		function onAgendaBreakupMultiDayEventsChanged() { popup.updateUI() }
-		function onMeteogramHoursChanged() { popup.updateMeteogram() }
+		function onAgendaBreakupMultiDayEventsChanged() { if (popup) popup.updateUI() }
+		function onMeteogramHoursChanged() { if (popup) popup.updateMeteogram() }
 	}
 
 	//---
 	Connections {
 		target: appletConfig
-		function onClock24hChanged() { popup.updateUI() }
+		function onClock24hChanged() { if (popup) popup.updateUI() }
 	}
 
 	//---
@@ -341,7 +341,7 @@ import "./weather/WeatherApi.js" as WeatherApi
 	}
 	Connections {
 		target: eventModel
-		function onError(errorType, msg) {
+		function onError(msg, errorType) {
 			logic.currentErrorMessage = msg
 			logic.currentErrorType = errorType
 			if (popup) popup.showError(logic.currentErrorMessage)

--- a/package/contents/ui/Logic.qml
+++ b/package/contents/ui/Logic.qml
@@ -17,6 +17,11 @@ import "./weather/WeatherApi.js" as WeatherApi
 		property var lastForecastErr: null
 		property bool pendingDailyUpdate: false
 		property bool pendingHourlyUpdate: false
+		property int weatherRetryAttempt: 0
+		property string pendingWeatherNetworkError: ""
+		property int eventRetryAttempt: 0
+		property string pendingEventNetworkError: ""
+		property double lastPollTriggeredAt: 0
 
 
 	//--- Main
@@ -32,7 +37,34 @@ import "./weather/WeatherApi.js" as WeatherApi
 		repeat: true
 		triggeredOnStart: true
 		interval: Math.max(60000, Number(plasmoid.configuration.eventsPollInterval || 20) * 60000)
-		onTriggered: logic.update()
+		onTriggered: {
+			var now = Date.now()
+			var resumedAfterTimerWasDue = lastPollTriggeredAt > 0
+				&& now - lastPollTriggeredAt > pollTimer.interval + 5000
+			lastPollTriggeredAt = now
+			if (resumedAfterTimerWasDue) {
+				// An overdue QML timer fires immediately after resume, before
+				// NetworkManager has rebuilt Wi-Fi, routing and DNS. Give it time.
+				resumeUpdateTimer.restart()
+			} else {
+				logic.update()
+			}
+		}
+	}
+	Timer {
+		id: resumeUpdateTimer
+		interval: 15000
+		repeat: false
+		onTriggered: logic.updateData()
+	}
+	Timer {
+		id: networkOnlineTimer
+		interval: 2000
+		repeat: false
+		onTriggered: {
+			resumeUpdateTimer.stop()
+			logic.updateData()
+		}
 	}
 
 	function update() {
@@ -42,20 +74,72 @@ import "./weather/WeatherApi.js" as WeatherApi
 
 	function updateData() {
 		logger.debug('updateData')
+		// Plasma can instantiate the applet before NetworkManager has finished
+		// reconnecting (for example immediately after login or a shell restart).
+		// Avoid firing requests that are guaranteed to fail with HTTP status 0;
+		// the network-status connection below refreshes everything once online.
+		if (!networkMonitor.isConnected) {
+			logger.debug('updateData skipped: network is not connected')
+			return
+		}
 		logic.updateEvents()
 		logic.updateWeather()
 	}
 
-
-
 	//--- Events
 	function updateEvents() {
+		if (!networkMonitor.isConnected) {
+			logic.scheduleEventRetry()
+			return
+		}
 		updateEventsTimer.restart()
 	}
 	Timer {
 		id: updateEventsTimer
 		interval: 200
 		onTriggered: logic.deferredUpdateEvents()
+	}
+	Timer {
+		id: eventRetryTimer
+		repeat: false
+		onTriggered: {
+			if (networkMonitor.isConnected) {
+				logic.updateEvents()
+			} else {
+				logic.scheduleEventRetry()
+			}
+		}
+	}
+	Timer {
+		id: eventNetworkErrorDisplayTimer
+		interval: 60000
+		repeat: false
+		onTriggered: {
+			if (pendingEventNetworkError) {
+				logic.currentErrorMessage = pendingEventNetworkError
+				logic.currentErrorType = ErrorType.NetworkError
+				if (popup) popup.showError(logic.currentErrorMessage)
+			}
+		}
+	}
+	function scheduleEventRetry() {
+		if (eventRetryTimer.running) {
+			return
+		}
+		var delays = [10000, 30000, 60000, 120000, 300000]
+		var delayIndex = Math.min(eventRetryAttempt, delays.length - 1)
+		eventRetryTimer.interval = delays[delayIndex]
+		eventRetryAttempt = Math.min(eventRetryAttempt + 1, delays.length - 1)
+		eventRetryTimer.start()
+	}
+	function clearEventNetworkRecovery() {
+		pendingEventNetworkError = ""
+		eventRetryAttempt = 0
+		eventRetryTimer.stop()
+		eventNetworkErrorDisplayTimer.stop()
+		if (logic.currentErrorType == ErrorType.NetworkError) {
+			logic.clearError()
+		}
 	}
 	function deferredUpdateEvents() {
 		var range = agendaModel.getDateRange(agendaModel.currentMonth)
@@ -70,6 +154,10 @@ import "./weather/WeatherApi.js" as WeatherApi
 
 		//--- Weather
 		function updateWeather(force) {
+			if (!networkMonitor.isConnected) {
+				logger.debug('updateWeather skipped: network is not connected')
+				return
+			}
 			if (WeatherApi.weatherIsSetup(plasmoid.configuration)) {
 				function shouldUpdateAt(lastAt) {
 					if (!lastAt) return true
@@ -100,6 +188,46 @@ import "./weather/WeatherApi.js" as WeatherApi
 			interval: 100
 			onTriggered: logic.deferredUpdateWeather()
 		}
+		Timer {
+			id: weatherRetryTimer
+			repeat: false
+			onTriggered: {
+				if (networkMonitor.isConnected) {
+					logic.updateWeather(true)
+				} else {
+					logic.scheduleWeatherRetry()
+				}
+			}
+		}
+		Timer {
+			id: weatherNetworkErrorDisplayTimer
+			interval: 60000
+			repeat: false
+			onTriggered: {
+				if (pendingWeatherNetworkError) {
+					logic.lastForecastErr = pendingWeatherNetworkError
+				}
+			}
+		}
+		function scheduleWeatherRetry() {
+			// Daily and hourly requests normally fail together. Let the first one
+			// schedule the shared retry instead of doubling the backoff.
+			if (weatherRetryTimer.running) {
+				return
+			}
+			var delays = [10000, 30000, 60000, 120000, 300000]
+			var delayIndex = Math.min(weatherRetryAttempt, delays.length - 1)
+			weatherRetryTimer.interval = delays[delayIndex]
+			weatherRetryAttempt = Math.min(weatherRetryAttempt + 1, delays.length - 1)
+			weatherRetryTimer.start()
+			logger.debug('Weather retry scheduled in ms', weatherRetryTimer.interval)
+		}
+		function clearWeatherRetry() {
+			pendingWeatherNetworkError = ""
+			weatherRetryAttempt = 0
+			weatherRetryTimer.stop()
+			weatherNetworkErrorDisplayTimer.stop()
+		}
 		function deferredUpdateWeather() {
 			var doDaily = pendingDailyUpdate
 			var doHourly = pendingHourlyUpdate
@@ -115,6 +243,7 @@ import "./weather/WeatherApi.js" as WeatherApi
 		}
 
 		function resetWeatherData() {
+			logic.clearWeatherRetry()
 			logic.dailyWeatherData = { "list": [] }
 			logic.hourlyWeatherData = { "list": [] }
 			logic.currentWeatherData = null
@@ -228,7 +357,11 @@ import "./weather/WeatherApi.js" as WeatherApi
 				var msg = i18n("Could not connect")
 				var errorMessage = i18n("HTTP Error %1: %2", xhr.status, msg)
 				errorMessage += '\n' + i18n("Will try again soon.")
-				logic.lastForecastErr = errorMessage
+				logic.pendingWeatherNetworkError = errorMessage
+				if (!weatherNetworkErrorDisplayTimer.running) {
+					weatherNetworkErrorDisplayTimer.start()
+				}
+				logic.scheduleWeatherRetry()
 			} else if (xhr && xhr.status == 429) {
 				// If there's an error, don't bother the API for another hour.
 				if (isDaily) logic.lastDailyForecastAt = nowMs
@@ -253,6 +386,7 @@ import "./weather/WeatherApi.js" as WeatherApi
 					data = localizeWeatherData(data)
 
 					logic.lastDailyForecastAt = Date.now()
+					logic.clearWeatherRetry()
 					logic.lastForecastErr = null
 					logic.dailyWeatherData = data
 				if (popup) {
@@ -269,6 +403,7 @@ import "./weather/WeatherApi.js" as WeatherApi
 						data = localizeWeatherData(data)
 
 						logic.lastHourlyForecastAt = Date.now()
+						logic.clearWeatherRetry()
 						logic.lastForecastErr = null
 						logic.hourlyWeatherData = data
 						logic.currentWeatherData = (data && data.current) ? data.current : ((data && data.list && data.list.length) ? data.list[0] : null)
@@ -336,12 +471,21 @@ import "./weather/WeatherApi.js" as WeatherApi
 		}
 	}
 	function clearError() {
+		currentErrorMessage = ""
 		currentErrorType = ErrorType.NoError
 		if (popup) popup.clearError()
 	}
 	Connections {
 		target: eventModel
 		function onError(msg, errorType) {
+			if (errorType == ErrorType.NetworkError) {
+				logic.pendingEventNetworkError = msg
+				logic.scheduleEventRetry()
+				if (!eventNetworkErrorDisplayTimer.running) {
+					eventNetworkErrorDisplayTimer.start()
+				}
+				return
+			}
 			logic.currentErrorMessage = msg
 			logic.currentErrorType = errorType
 			if (popup) popup.showError(logic.currentErrorMessage)
@@ -353,6 +497,7 @@ import "./weather/WeatherApi.js" as WeatherApi
 		target: eventModel
 		function onCalendarFetched(calendarId, data) {
 			logger.debug('onCalendarFetched', calendarId)
+			logic.clearEventNetworkRecovery()
 			// logger.debug('onCalendarFetched', calendarId, JSON.stringify(data, null, '\t'))
 			if (popup) popup.deferredUpdateUI()
 		}
@@ -378,11 +523,13 @@ import "./weather/WeatherApi.js" as WeatherApi
 	Connections {
 		target: networkMonitor
 		function onIsConnectedChanged() {
+			logger.debug('NetworkMonitor.isConnected changed', networkMonitor.isConnected)
 			if (networkMonitor.isConnected) {
-				if (logic.currentErrorType == ErrorType.NetworkError) {
-					logic.clearError()
-				}
-				logic.update()
+				// NetworkManager can announce Full just before DNS is usable. A
+				// short settle delay avoids one final status-0 request on resume.
+				networkOnlineTimer.restart()
+			} else {
+				networkOnlineTimer.stop()
 			}
 		}
 	}

--- a/package/contents/ui/MeteogramView.qml
+++ b/package/contents/ui/MeteogramView.qml
@@ -125,9 +125,13 @@ Item {
 				yAxisRainMax = 100
 			}
 
-			yAxisScale = Math.ceil((yDataMax-yDataMin) / (yAxisScaleCount))
+			yAxisScale = Math.max(1, Math.ceil((yDataMax-yDataMin) / Math.max(1, yAxisScaleCount)))
 			yAxisMin = Math.floor(yDataMin)
 			yAxisMax = Math.ceil(yDataMax)
+			if (yAxisMin >= yAxisMax) {
+				yAxisMin -= 1
+				yAxisMax += 1
+			}
 		}
 
 		function iconsInRange(gData, s, e) {
@@ -181,9 +185,13 @@ Item {
 
 
 		function gridPoint(x, y) {
+			var xRange = xAxisMax - xAxisMin
+			var yRange = yAxisMax - yAxisMin
+			if (!isFinite(xRange) || xRange <= 0) xRange = 1
+			if (!isFinite(yRange) || yRange <= 0) yRange = 1
 			return {
-				x: (x - xAxisMin) / (xAxisMax - xAxisMin) * gridWidth + gridX,
-				y: gridHeight - (y - yAxisMin) / (yAxisMax - yAxisMin) * gridHeight + gridY,
+				x: (x - xAxisMin) / xRange * gridWidth + gridX,
+				y: gridHeight - (y - yAxisMin) / yRange * gridHeight + gridY,
 			}
 		}
 
@@ -252,6 +260,10 @@ Item {
 
 						if (graph.gridData.length < 2) return
 						if (graph.yAxisMin === graph.yAxisMax) return
+						var yStep = Number(graph.yAxisScale)
+						var xStep = Number(graph.xAxisScale)
+						if (!isFinite(yStep) || yStep <= 0) yStep = 1
+						if (!isFinite(xStep) || xStep <= 0) xStep = 1
 
 						// rain
 						graph.showYAxisRainMax = false
@@ -273,7 +285,7 @@ Item {
 						}
 
 						// yAxis scale
-						for (var y = graph.yAxisMin; y <= graph.yAxisMax; y += graph.yAxisScale) {
+						for (var y = graph.yAxisMin, yTicks = 0; y <= graph.yAxisMax && yTicks < 256; y += yStep, yTicks++) {
 							ctx.strokeStyle = "" + appletConfig.meteogramScaleColor
 							ctx.lineWidth = 1
 							drawLine(ctx, graph.xAxisMin, y, graph.xAxisMax, y)
@@ -288,7 +300,7 @@ Item {
 						}
 
 						// xAxis scale
-						for (var x = graph.xAxisMin; x <= graph.xAxisMax; x += graph.xAxisScale) {
+						for (var x = graph.xAxisMin, xTicks = 0; x <= graph.xAxisMax && xTicks < 256; x += xStep, xTicks++) {
 							ctx.strokeStyle = "" + appletConfig.meteogramScaleColor
 							ctx.lineWidth = 1
 							drawLine(ctx, x, graph.yAxisMin, x, graph.yAxisMax)

--- a/package/contents/ui/NetworkMonitor.qml
+++ b/package/contents/ui/NetworkMonitor.qml
@@ -81,8 +81,10 @@ QtObject {
 			// Failed to load PlasmaNM, so treat it as connected.
 			return true
 		} else {
-			// NetworkManager::Connectivity: None(1) is offline; Portal/Limited/Full are usable.
-			return connectivity > 1
+			// Internet APIs need NetworkManager::Connectivity::Full (4). Portal and
+			// Limited are common transient states while Wi-Fi is reconnecting after
+			// resume, but XMLHttpRequest still fails there with HTTP status 0.
+			return connectivity >= 4
 		}
 	}
 

--- a/package/contents/ui/calendars/CalendarManager.qml
+++ b/package/contents/ui/calendars/CalendarManager.qml
@@ -46,7 +46,7 @@ Item {
 		var calendarList = getCalendarList()
 		for (var i = 0; i < calendarList.length; i++) {
 			var calendar = calendarList[i]
-			if (calendarId === calendar.id) {
+			if (calendarId === calendar.id || (calendarId === "primary" && calendar.primary === true)) {
 				return calendar
 			}
 		}

--- a/package/contents/ui/calendars/GoogleApiSession.qml
+++ b/package/contents/ui/calendars/GoogleApiSession.qml
@@ -6,6 +6,8 @@ QtObject {
 	id: googleApiSession
 
 	readonly property string accessToken: plasmoid.configuration.accessToken
+	property bool refreshInProgress: false
+	property var refreshWaiters: []
 
 	//--- Refresh Credentials
 	function checkAccessToken(callback) {
@@ -18,25 +20,44 @@ QtObject {
 	}
 
 	function updateAccessToken(callback) {
+		refreshWaiters.push(callback)
+		if (refreshInProgress) return
+		refreshInProgress = true
+		function finishRefresh(err) {
+			var waiters = refreshWaiters.slice(0)
+			refreshWaiters = []
+			refreshInProgress = false
+			for (var i = 0; i < waiters.length; i++) waiters[i](err || null)
+		}
 		// logger.debug('accessTokenExpiresAt', plasmoid.configuration.accessTokenExpiresAt)
 		// logger.debug('                 now', Date.now())
 		// logger.debug('refreshToken', plasmoid.configuration.refreshToken)
 		if (plasmoid.configuration.refreshToken) {
 			logger.debug('updateAccessToken')
 			fetchNewAccessToken(function(err, data, xhr) {
-				if (err || (!err && data && data.error)) {
-					logger.log('Error when using refreshToken:', err, data)
-					return callback(err)
+				var tokenData = null
+				if (!err) {
+					try {
+						tokenData = typeof data === 'string' ? JSON.parse(data) : data
+					} catch (parseError) {
+						err = "Invalid response while refreshing Google access token."
+					}
 				}
-				logger.debug('onAccessToken', data)
-				data = JSON.parse(data)
+				if (err || (tokenData && tokenData.error)) {
+					logger.log('Error when using refreshToken:', err, data)
+					return finishRefresh(err || "Failed to refresh Google access token.")
+				}
+				if (!tokenData || !tokenData.access_token) {
+					return finishRefresh("Missing access token in Google refresh response.")
+				}
+				logger.debug('onAccessToken', tokenData)
 
-				googleApiSession.applyAccessToken(data)
+				googleApiSession.applyAccessToken(tokenData)
 
-				callback(null)
+				finishRefresh(null)
 			})
 		} else {
-			callback('No refresh token. Cannot update access token.')
+			finishRefresh('No refresh token. Cannot update access token.')
 		}
 	}
 

--- a/package/contents/ui/calendars/GoogleCalendarManager.qml
+++ b/package/contents/ui/calendars/GoogleCalendarManager.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import org.kde.kirigami as Kirigami
 
 import "../ErrorType.js" as ErrorType
 import "../Shared.js" as Shared
@@ -261,8 +262,9 @@ CalendarManager {
 	function parseEvent(calendar, event) {
 		event.description = event.description || ""
 		event.backgroundColor = parseColor(calendar, event)
-		event.canEdit = (calendar.accessRole == 'writer' || calendar.accessRole == 'owner') && !event.recurringEventId // We cannot currently edit repeating events.
+		event.canEdit = !!calendar && (calendar.accessRole == 'writer' || calendar.accessRole == 'owner') && !event.recurringEventId // We cannot currently edit repeating events.
 		if (plasmoid.configuration.googleHideGoalsDesc
+			&& event.organizer
 			&& event.organizer.email == "unknownorganizer@calendar.google.com"
 			&& event.organizer.displayName == "Google Calendar"
 		) {
@@ -307,7 +309,7 @@ CalendarManager {
 	function parseColor(calendar, event) {
 		var colorId = parseColorId('event', event.colorId)
 		// event.backgroundColor is a hardcoded color (like the debug calendar)
-		return event.backgroundColor || colorId || calendar.backgroundColor
+		return event.backgroundColor || colorId || (calendar && calendar.backgroundColor) || Kirigami.Theme.highlightColor.toString()
 	}
 
 

--- a/package/contents/ui/calendars/GoogleTasksManager.qml
+++ b/package/contents/ui/calendars/GoogleTasksManager.qml
@@ -3,6 +3,7 @@ import org.kde.plasma.core as PlasmaCore
 import org.kde.kirigami as Kirigami
 
 import "../Shared.js" as Shared
+import "../ErrorType.js" as ErrorType
 import "../lib/Async.js" as Async
 import "../lib/Requests.js" as Requests
 
@@ -115,7 +116,10 @@ CalendarManager {
 	function fetchGoogleAccountTasks_err(err, data, xhr) {
 		logger.debug('fetchGoogleAccountTasks_err', err, data, xhr)
 		googleTasksManager.asyncRequestsDone += 1
-		return handleError(err, data, xhr)
+		var httpCode = xhr ? xhr.status : 0
+		var msg = httpCode === 0 ? i18n("Could not connect") : (err || i18n("Google Tasks request failed"))
+		googleTasksManager.error(i18n("HTTP Error %1: %2", httpCode, msg),
+			httpCode === 0 ? ErrorType.NetworkError : ErrorType.UnknownError)
 	}
 	function fetchGoogleAccountTasks_done(results) {
 		for (var i = 0; i < results.length; i++) {

--- a/package/contents/ui/config/ConfigGoogleCalendar.qml
+++ b/package/contents/ui/config/ConfigGoogleCalendar.qml
@@ -196,6 +196,12 @@ ConfigPage {
 
 			if (exitCode !== 0) {
 				var msg = ("" + (stderr || stdout || "")).trim()
+				if (exitCode === 126 || exitCode === 127) {
+					page.showAdvanced = true
+					page.showHelp = true
+					showStatus(i18n("Google login helper is unavailable. Use the Advanced manual login method below."), Kirigami.MessageType.Warning)
+					return
+				}
 				showStatus(page.localizedErrorMessage(msg) || i18n("Google login failed."), Kirigami.MessageType.Error)
 				return
 			}

--- a/package/contents/ui/lib/Async.js
+++ b/package/contents/ui/lib/Async.js
@@ -2,16 +2,24 @@
 // Version 1
 
 function _taskCallback(asyncObj, key, err, taskResult) {
+	if (asyncObj.completedKeys[key]) return
+	asyncObj.completedKeys[key] = true
 	asyncObj.numCompleted += 1
 	if (err) {
 		asyncObj.err = err
-		asyncObj.finalCallback(err)
+		if (!asyncObj.finalCalled) {
+			asyncObj.finalCalled = true
+			asyncObj.finalCallback(err)
+		}
 	} else if (asyncObj.err) {
 		// Skip
 	} else {
 		asyncObj.results[key] = taskResult
 		if (asyncObj.numCompleted >= asyncObj.numTasks) {
-			asyncObj.finalCallback(null, asyncObj.results)
+			if (!asyncObj.finalCalled) {
+				asyncObj.finalCalled = true
+				asyncObj.finalCallback(null, asyncObj.results)
+			}
 		}
 	}
 }
@@ -26,6 +34,8 @@ function parallel(tasks, finalCallback) {
 		asyncObj.numCompleted = 0
 		asyncObj.err = null
 		asyncObj.results = []
+		asyncObj.completedKeys = ({})
+		asyncObj.finalCalled = false
 		asyncObj.finalCallback = finalCallback
 
 		for (var i = 0; i < tasks.length; i++) {

--- a/package/contents/ui/lib/Requests.js
+++ b/package/contents/ui/lib/Requests.js
@@ -6,22 +6,28 @@ function request(opt, callback) {
 		opt = { url: opt }
 	}
 	var req = new XMLHttpRequest()
+	var completed = false
+	function finish(err, data) {
+		if (completed) return
+		completed = true
+		callback(err, data, req)
+	}
 	req.onerror = function() {
 		// Network Error / No Connection
 		console.log('XMLHttpRequest.onerror', req.status)
 		var msg = "HTTP Error " + req.status
-		callback(msg, null, req)
+		finish(msg, null)
 	}
 	req.onreadystatechange = function() {
 		if (req.readyState === XMLHttpRequest.DONE) { // https://xhr.spec.whatwg.org/#dom-xmlhttprequest-done
 			if (200 <= req.status && req.status < 400) {
-				callback(null, req.responseText, req)
+				finish(null, req.responseText)
 			} else {
 				if (req.status === 0) {
 					console.log('HTTP 0 Headers: \n' + req.getAllResponseHeaders())
 				}
 				var msg = "HTTP Error " + req.status
-				callback(msg, req.responseText, req)
+				finish(msg, req.responseText)
 			}
 		}
 	}

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -225,7 +225,7 @@ PlasmoidItem {
 
 	Plasmoid.backgroundHints: plasmoid.configuration.showBackground ? PlasmaCore.Types.StandardBackground : PlasmaCore.Types.NoBackground
 
-	property bool isDesktopContainment: root.location == PlasmaCore.Types.Floating
+	property bool isDesktopContainment: Plasmoid.formFactor === PlasmaCore.Types.Planar
 	preferredRepresentation: isDesktopContainment ? fullRepresentation : compactRepresentation
 	compactRepresentation: clockComponent
 	fullRepresentation: popupComponent


### PR DESCRIPTION
## Summary

- replace the mutation-based Google Tasks ordering algorithm with a cycle-safe hierarchy traversal
- prevent normal calendar events from being appended more than once
- deduplicate events exposed both through Google Calendar and Akonadi/PIM, while preserving same-looking events from independent calendars
- serialize Google access-token refreshes and guard asynchronous callbacks against multiple completion
- store access-token expiry timestamps without 32-bit overflow
- prevent invalid meteogram scales from producing unbounded rendering loops
- use the Planar form factor to select the full desktop representation
- handle a missing OAuth helper without exposing a raw shell error
- delay overdue polling after suspend, wait for full connectivity, and retry transient calendar/weather failures

Closes #11.

## Root causes

`AgendaModel.sortSubTasks()` repeatedly spliced the array it was iterating. Unusual or cyclic parent relationships could keep moving tasks indefinitely, while a later traversal could append normal events twice. Calendar data could also arrive through both the direct Google provider and Akonadi/PIM.

The Google Calendar and Tasks managers can refresh concurrently. The access-token expiry was stored as a 32-bit `uint`, even though JavaScript epoch milliseconds exceed that range, and an XHR error could complete the same asynchronous operation more than once. An invalid or zero meteogram scale could make a canvas tick loop unbounded.

After resume, an overdue QML timer could also fire while NetworkManager still reported stale connectivity, before Wi-Fi, routing, and DNS were ready. The recovery path now waits for full connectivity, adds a short settle delay, retries transient failures with bounded backoff, and clears stale network errors after a successful fetch.

## Validation

- tested in a live Plasma 6.6.5 Wayland session with more than 500 calendar/task items
- reproduced the resume race from system logs: polling preceded restored global connectivity by roughly 12 seconds
- reloaded the final QML in Plasma with agenda and weather populated and no stale `HTTP Error 0` notification
- no QML `TypeError`, `ReferenceError`, or `SyntaxError` after reloading plasmashell
- plasmashell remains responsive and memory usage stabilizes after synchronization
- automated tests exercise normal event uniqueness, task parent/child ordering, cyclic task hierarchies, task IDs shared by different lists, PIM/Google deduplication in either source order, and preservation of legitimate same-looking events
- XML, JSON, shell syntax, and Git whitespace checks pass

## Compatibility notes

This intentionally does not modify `PlasmaCalendarManager`'s PIM model handling because #10 already provides a more complete fix for that code path.

The full CMake build was not available in the test environment because the ECM and Qt 6 NetworkAuth development packages were missing. This PR does not modify the C++ OAuth helper; its unavailable-helper path and installer messaging were tested separately.
